### PR TITLE
Move the `mouseup` listener to the document

### DIFF
--- a/test/items.html
+++ b/test/items.html
@@ -126,6 +126,13 @@
           expect(item.hasAttribute('focus-ring')).to.be.false;
         });
 
+        it('set this._mousedown to false if mouseup was outside', () => {
+          fire(item, 'mousedown');
+          expect(item._mousedown).to.be.true;
+          fire(document, 'mouseup');
+          expect(item._mousedown).to.be.false;
+        });
+
         it('should be selectable with mouse click', () => {
           item.click();
           expect(item.selected).to.be.true;

--- a/vaadin-list-item-mixin.html
+++ b/vaadin-list-item-mixin.html
@@ -40,15 +40,33 @@ This program is available under Apache License Version 2.0, available at https:/
       };
     }
 
+    constructor() {
+      super();
+      this._boundMouseUpListener = this._mouseUpListener.bind(this);
+    }
+
     ready() {
       super.ready();
       this.addEventListener('focus', e => this._setFocused(true), true);
       this.addEventListener('blur', e => this._setFocused(false), true);
       this.addEventListener('mousedown', e => this._setActive(this._mousedown = true));
-      this.addEventListener('mouseup', e => this._setActive(this._mousedown = false));
       this.addEventListener('keydown', e => this._onKeydown(e));
       this.addEventListener('keyup', e => this._onKeyup(e));
       this.addEventListener('click', e => this._toggle());
+    }
+
+    connectedCallback() {
+      super.connectedCallback();
+      document.addEventListener('mouseup', this._boundMouseUpListener);
+    }
+
+    disconnectedCallback() {
+      super.disconnectedCallback();
+      document.removeEventListener('mouseup', this._boundMouseUpListener);
+    }
+
+    _mouseUpListener() {
+      this._setActive(this._mousedown = false);
     }
 
     _toggle() {


### PR DESCRIPTION
I don't like document listeners inside components, but it looks like we have to add this one in order to unset the internal `this._mousedown`, which is checked when we're setting the `focus-ring` attribute.

Fixes #49

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-tabs/54)
<!-- Reviewable:end -->
