### PR TITLE
Fix inline demo for webcomponents.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,19 +18,18 @@
   <template>
     <script src="../webcomponentsjs/webcomponents-lite.js"></script>
     <link rel="import" href="vaadin-tabs.html">
-    <next-code-block>
-    </next-code-block>
+    <next-code-block></next-code-block>
   </template>
 </custom-element-demo>
 ```
 -->
 ```html
-  <vaadin-tabs selected="4">
-    <vaadin-tab>Page 1</vaadin-tab>
-    <vaadin-tab>Page 2</vaadin-tab>
-    <vaadin-tab>Page 3</vaadin-tab>
-    <vaadin-tab>Page 4</vaadin-tab>
-  </vaadin-tabs>
+<vaadin-tabs selected="3">
+  <vaadin-tab>Page 1</vaadin-tab>
+  <vaadin-tab>Page 2</vaadin-tab>
+  <vaadin-tab>Page 3</vaadin-tab>
+  <vaadin-tab>Page 4</vaadin-tab>
+</vaadin-tabs>
 ```
 
 [<img src="https://raw.githubusercontent.com/vaadin/vaadin-tabs/master/screenshot.png" alt="Screenshot of vaadin-tabs">](https://vaadin.com/elements/-/element/vaadin-tabs)


### PR DESCRIPTION
That line break in `<next-code-block>` tag causes demo to not displaying correctly.
Also, non-existing tab number passed to `selected` attribute looks confusing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-tabs/65)
<!-- Reviewable:end -->
