### PR TITLE
Update theme

### DIFF
--- a/demo/tabs-valo-theme-demos.html
+++ b/demo/tabs-valo-theme-demos.html
@@ -77,6 +77,37 @@
       </template>
     </vaadin-demo-snippet>
 
+    <h3>Hide Scroll Buttons</h3>
+    <vaadin-demo-snippet id='tabs-valo-theme-demos-hide-scroll-buttons'>
+      <template preserve-content>
+        <vaadin-tabs theme="hide-scroll-buttons">
+          <vaadin-tab>Tab one</vaadin-tab>
+          <vaadin-tab>Tab two</vaadin-tab>
+          <vaadin-tab>Tab three</vaadin-tab>
+          <vaadin-tab>Tab four</vaadin-tab>
+          <vaadin-tab>Tab five</vaadin-tab>
+          <vaadin-tab>Tab six</vaadin-tab>
+          <vaadin-tab>Tab seven</vaadin-tab>
+          <vaadin-tab>Tab eight</vaadin-tab>
+          <vaadin-tab>Tab nine</vaadin-tab>
+          <vaadin-tab>Tab ten</vaadin-tab>
+          <vaadin-tab>Tab eleven</vaadin-tab>
+          <vaadin-tab>Tab twelve</vaadin-tab>
+          <vaadin-tab>Tab thirteen</vaadin-tab>
+          <vaadin-tab>Tab fourteen</vaadin-tab>
+          <vaadin-tab>Tab fifteen</vaadin-tab>
+        </vaadin-tabs>
+
+        <br>
+
+        <vaadin-tabs orientation="vertical" theme="minimal">
+          <vaadin-tab>Tab one</vaadin-tab>
+          <vaadin-tab>Tab two</vaadin-tab>
+          <vaadin-tab>Tab three</vaadin-tab>
+        </vaadin-tabs>
+      </template>
+    </vaadin-demo-snippet>
+
     <h3>Small Size</h3>
     <vaadin-demo-snippet id='tabs-valo-theme-demos-small-size'>
       <template preserve-content>
@@ -111,52 +142,6 @@
           <vaadin-tab>Tab one</vaadin-tab>
           <vaadin-tab>Tab two</vaadin-tab>
           <vaadin-tab>Tab three</vaadin-tab>
-        </vaadin-tabs>
-      </template>
-    </vaadin-demo-snippet>
-
-    <h3>Pills</h3>
-    <vaadin-demo-snippet id='tabs-valo-theme-demos-pills'>
-      <template preserve-content>
-        <vaadin-tabs theme="pill">
-          <vaadin-tab>Tab one</vaadin-tab>
-          <vaadin-tab>Tab two</vaadin-tab>
-          <vaadin-tab>Tab three</vaadin-tab>
-          <vaadin-tab>Tab four</vaadin-tab>
-        </vaadin-tabs>
-
-        <br><br>
-
-        <vaadin-tabs theme="pill">
-          <vaadin-tab>
-            <iron-icon icon="valo:user"></iron-icon>
-            <span>Tab one</span>
-          </vaadin-tab>
-          <vaadin-tab>
-            <iron-icon icon="valo:plane"></iron-icon>
-            <span>Tab two</span>
-          </vaadin-tab>
-          <vaadin-tab>
-            <iron-icon icon="valo:bell"></iron-icon>
-            <span>Tab three</span>
-          </vaadin-tab>
-        </vaadin-tabs>
-
-        <br><br>
-
-        <vaadin-tabs theme="pill">
-          <vaadin-tab theme="icon-on-top">
-            <iron-icon icon="valo:user"></iron-icon>
-            <span>Tab one</span>
-          </vaadin-tab>
-          <vaadin-tab theme="icon-on-top">
-            <iron-icon icon="valo:plane"></iron-icon>
-            <span>Tab two</span>
-          </vaadin-tab>
-          <vaadin-tab theme="icon-on-top">
-            <iron-icon icon="valo:bell"></iron-icon>
-            <span>Tab three</span>
-          </vaadin-tab>
         </vaadin-tabs>
       </template>
     </vaadin-demo-snippet>

--- a/theme/valo/vaadin-tab.html
+++ b/theme/valo/vaadin-tab.html
@@ -1,6 +1,7 @@
 <link rel="import" href="../../../vaadin-valo-theme/color.html">
 <link rel="import" href="../../../vaadin-valo-theme/sizing.html">
 <link rel="import" href="../../../vaadin-valo-theme/style.html">
+<link rel="import" href="../../../vaadin-valo-theme/typography.html">
 
 <dom-module id="valo-tab" theme-for="vaadin-tab">
   <template>
@@ -8,15 +9,22 @@
       :host {
         box-sizing: border-box;
         padding: .25em 1em;
+        font-family: var(--valo-font-family);
+        font-size: var(--valo-font-size-m);
+        line-height: var(--valo-line-height);
         font-weight: 500;
+        opacity: 1;
         color: var(--valo-contrast-60pct);
         transition: 0.2s color, 0.2s transform;
+        flex-shrink: 0;
         display: flex;
         align-items: center;
         position: relative;
         cursor: pointer;
         transform-origin: 50% 100%;
         outline: none;
+        -webkit-font-smoothing: antialiased;
+        -moz-osx-font-smoothing: grayscale;
       }
 
       :host([orientation="vertical"]) {
@@ -78,7 +86,7 @@
       }
 
       :host::after {
-        box-shadow: 0 0 1px 4px var(--valo-primary-color);
+        box-shadow: 0 0 0 4px var(--valo-primary-color);
         opacity: 0.15;
         transition: 0.15s 0.02s transform, 0.8s 0.17s opacity;
       }
@@ -141,6 +149,14 @@
 
       :host([theme~="icon-on-top"]) ::slotted(iron-icon) {
         margin: 0;
+      }
+
+      /* Disabled */
+
+      :host([disabled]) {
+        pointer-events: none;
+        opacity: 1;
+        color: var(--valo-disabled-text-color);
       }
     </style>
   </template>

--- a/theme/valo/vaadin-tabs.html
+++ b/theme/valo/vaadin-tabs.html
@@ -18,6 +18,10 @@
         min-height: var(--valo-size-l);
       }
 
+      :host([orientation="horizontal"]) [part="tabs"] ::slotted(vaadin-tab) {
+        justify-content: center;
+      }
+
       :host([orientation="vertical"]) {
         box-shadow: -1px 0 0 0 var(--valo-contrast-10pct);
       }
@@ -28,12 +32,14 @@
         z-index: 1;
         font-family: valo-icons;
         color: var(--valo-tertiary-text-color);
-        font-size: 24px;
-        line-height: 24px;
-        width: 30px;
-        text-align: center;
+        font-size: var(--valo-icon-size);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        width: 1.5em;
+        height: 100%;
         transition: 0.2s opacity;
-        top: calc((100% - 24px) / 2);
+        top: 0;
       }
 
       [part="forward-button"]:hover,
@@ -46,11 +52,11 @@
       }
 
       [part="forward-button"]::after {
-        content: "\e906";
+        content: var(--valo-icons-chevron-right);
       }
 
       [part="back-button"]::after {
-        content: "\e903";
+        content: var(--valo-icons-chevron-left);
       }
 
       /* Tabs overflow */
@@ -67,34 +73,34 @@
 
       /* Both ends overflowing */
       :host([overflow~="start"][overflow~="end"]:not([orientation="vertical"])) [part="tabs"] {
-        --_valo-tabs-overflow-mask-image: linear-gradient(90deg, transparent 30px, #000 60px, #000 calc(100% - 60px), transparent calc(100% - 30px));
+        --_valo-tabs-overflow-mask-image: linear-gradient(90deg, transparent 2em, #000 4em, #000 calc(100% - 4em), transparent calc(100% - 2em));
       }
 
       /* End overflowing */
       :host([overflow~="end"]:not([orientation="vertical"])) [part="tabs"] {
-        --_valo-tabs-overflow-mask-image: linear-gradient(90deg, #000 calc(100% - 60px), transparent calc(100% - 30px));
+        --_valo-tabs-overflow-mask-image: linear-gradient(90deg, #000 calc(100% - 4em), transparent calc(100% - 2em));
       }
 
       /* Start overflowing */
       :host([overflow~="start"]:not([orientation="vertical"])) [part="tabs"] {
-        --_valo-tabs-overflow-mask-image: linear-gradient(90deg, transparent 30px, #000 60px);
+        --_valo-tabs-overflow-mask-image: linear-gradient(90deg, transparent 2em, #000 4em);
       }
 
       /* Vertical tabs overflow */
 
       /* Both ends overflowing */
       :host([overflow~="start"][overflow~="end"][orientation="vertical"]) [part="tabs"] {
-        --_valo-tabs-overflow-mask-image: linear-gradient(transparent, #000 30px, #000 calc(100% - 30px), transparent);
+        --_valo-tabs-overflow-mask-image: linear-gradient(transparent, #000 2em, #000 calc(100% - 2em), transparent);
       }
 
       /* End overflowing */
       :host([overflow~="end"][orientation="vertical"]) [part="tabs"] {
-        --_valo-tabs-overflow-mask-image: linear-gradient(#000 calc(100% - 30px), transparent);
+        --_valo-tabs-overflow-mask-image: linear-gradient(#000 calc(100% - 2em), transparent);
       }
 
       /* Start overflowing */
       :host([overflow~="start"][orientation="vertical"]) [part="tabs"] {
-        --_valo-tabs-overflow-mask-image: linear-gradient(transparent, #000 30px);
+        --_valo-tabs-overflow-mask-image: linear-gradient(transparent, #000 2em);
       }
 
       :host ::slotted(:not(vaadin-tab)) {
@@ -127,6 +133,24 @@
       :host([theme~="minimal"]) [part="tabs"] ::slotted(vaadin-tab[selected])::after,
       :host([theme~="pill"]) [part="tabs"] ::slotted(vaadin-tab[selected])::after {
         display: none;
+      }
+
+      /* No-button theme */
+      :host([theme~="hide-scroll-buttons"]) [part="back-button"],
+      :host([theme~="hide-scroll-buttons"]) [part="forward-button"] {
+        display: none;
+      }
+
+      :host([theme~="hide-scroll-buttons"][overflow~="start"][overflow~="end"]:not([orientation="vertical"])) [part="tabs"] {
+        --_valo-tabs-overflow-mask-image: linear-gradient(90deg, transparent, #000 2em, #000 calc(100% - 2em), transparent 100%);
+      }
+
+      :host([theme~="hide-scroll-buttons"][overflow~="end"]:not([orientation="vertical"])) [part="tabs"] {
+        --_valo-tabs-overflow-mask-image: linear-gradient(90deg, #000 calc(100% - 2em), transparent 100%);
+      }
+
+      :host([theme~="hide-scroll-buttons"][overflow~="start"]:not([orientation="vertical"])) [part="tabs"] {
+        --_valo-tabs-overflow-mask-image: linear-gradient(90deg, transparent, #000 2em);
       }
 
       /* Pill theme */


### PR DESCRIPTION
Since the default themes were removed, the Valo theme didn’t work properly. Add the missing properties back.

Remove the “pill” theme variation for now, it was only experimental.

Add a new “hide-scroll-buttons” variation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-tabs/69)
<!-- Reviewable:end -->
