### PR TITLE
Workaround mask-image CSS property to prevent crash in Edge

### DIFF
--- a/theme/valo/vaadin-tabs.html
+++ b/theme/valo/vaadin-tabs.html
@@ -64,9 +64,18 @@
       [part="tabs"] {
         --_valo-tabs-overflow-mask-image: none;
         -webkit-mask-image: var(--_valo-tabs-overflow-mask-image);
-        mask-image: var(--_valo-tabs-overflow-mask-image);
         /* For IE11 */
         min-height: var(--valo-size-l);
+      }
+
+      /*
+        TODO: CSS custom property in `mask-image` causes crash in Edge
+        see https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/15415089/
+      */
+      @-moz-document url-prefix() {
+        [part="tabs"] {
+          mask-image: var(--_valo-tabs-overflow-mask-image);
+        }
       }
 
       /* Horizontal tabs overflow */


### PR DESCRIPTION
Connected to vaadin/vaadin-valo-styles#45

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-tabs/73)
<!-- Reviewable:end -->
