### PR TITLE
Fix horizontal tabs width as a flex child in IE11

### DIFF
--- a/src/vaadin-tabs.html
+++ b/src/vaadin-tabs.html
@@ -28,7 +28,7 @@ This program is available under Apache License Version 2.0, available at https:/
       }
 
       :host([orientation="horizontal"]) [part="tabs"] {
-        flex: 1;
+        flex-grow: 1;
         display: flex;
         align-self: stretch;
         overflow-x: auto;

--- a/test/nav.html
+++ b/test/nav.html
@@ -21,6 +21,18 @@
       </vaadin-tabs>
     </template>
   </test-fixture>
+
+  <test-fixture id="flex-child">
+    <template>
+      <div style="display: flex; width: 400px;">
+        <vaadin-tabs>
+          <vaadin-tab>Foo</vaadin-tab>
+          <vaadin-tab>Bar</vaadin-tab>
+        </vaadin-tabs>
+      </div>
+    </template>
+  </test-fixture>
+
   <script>
     const safari10 = /Apple.* Version\/(9|10)/.test(navigator.userAgent);
 
@@ -129,5 +141,24 @@
         });
       });
     });
+
+    describe('flex-child', () => {
+      let nav;
+
+      beforeEach(done => {
+        const wrapper = fixture('flex-child');
+        nav = wrapper.querySelector('vaadin-tabs');
+        Polymer.RenderStatus.afterNextRender(nav, () => {
+          nav._observer.flush();
+          done();
+        });
+      });
+
+      it('should have width above zero', () => {
+        expect(nav.offsetWidth).to.be.above(0);
+      });
+
+    });
+
   </script>
 </body>


### PR DESCRIPTION
Connects to https://github.com/vaadin/components-team-tasks/issues/321

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-tabs/80)
<!-- Reviewable:end -->
