### PR TITLE
Add link theme for vaadin-tab

### DIFF
--- a/theme/lumo/vaadin-tab.html
+++ b/theme/lumo/vaadin-tab.html
@@ -115,6 +115,18 @@
         margin-right: 0;
       }
 
+      :host ::slotted(a) {
+        display: flex;
+        align-items: center;
+        width: calc(100% + 2em);
+        height: 100%;
+        margin: -.25em -1em;
+        padding: .25em 1em;
+        text-decoration: none;
+        color: inherit;
+        outline: none;
+      }
+
       :host([theme~="icon-on-top"]) {
         display: flex;
         flex-direction: column;


### PR DESCRIPTION
Fixes #81

This feature was inspired by work on the [elements-viewer](https://web-padawan.github.io/elements-viewer/) navigation where I had to use absolute positioning to achieve what I needed: https://github.com/web-padawan/elements-viewer/blob/master/src/viewer-link.html#L13

@jouni PTAL

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-tabs/82)
<!-- Reviewable:end -->
