### PR TITLE
Fix horizontal tabs scroll width as a flex child in IE11

### DIFF
--- a/test/nav.html
+++ b/test/nav.html
@@ -158,6 +158,11 @@
         expect(nav.offsetWidth).to.be.above(0);
       });
 
+      it('should not scroll', () => {
+        // Edge & IE11 apply roundings to the metrics, need to assert by 1px
+        expect(nav.$.scroll.scrollWidth).to.be.closeTo(nav.$.scroll.offsetWidth, 1);
+      });
+
     });
 
   </script>

--- a/theme/lumo/vaadin-tab.html
+++ b/theme/lumo/vaadin-tab.html
@@ -25,6 +25,7 @@
         outline: none;
         -webkit-font-smoothing: antialiased;
         -moz-osx-font-smoothing: grayscale;
+        overflow: hidden;
       }
 
       :host([orientation="vertical"]) {


### PR DESCRIPTION
Fixes vaadin/components-team-tasks#321

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-tabs/83)
<!-- Reviewable:end -->
