### PR TITLE
Reorganize demos

### DIFF
--- a/demo/demos.json
+++ b/demo/demos.json
@@ -2,36 +2,36 @@
   "name": "Vaadin Tabs",
   "pages": [
   {
-    "name": "Basic Examples",
+    "name": "Basics",
     "url": "tabs-basic-demos",
     "src": "tabs-basic-demos.html",
     "meta": {
       "title": "vaadin-tabs Basic Examples",
       "description": "",
       "image": ""
-     }
+    }
   }
   ,
   {
-    "name": "Advanced Usage",
-    "url": "tabs-advanced-demos",
-    "src": "tabs-advanced-demos.html",
+    "name": "Integration",
+    "url": "tabs-integration-demos",
+    "src": "tabs-integration-demos.html",
     "meta": {
-      "title": "vaadin-tabs Advanced Examples",
+      "title": "vaadin-tabs Integration Examples",
       "description": "",
       "image": ""
-     }
+    }
   }
   ,
   {
-    "name": "Lumo Theme Variations",
+    "name": "Theme Variants",
     "url": "tabs-lumo-theme-demos",
     "src": "tabs-lumo-theme-demos.html",
     "meta": {
-      "title": "vaadin-tabs Lumo Theme Variations",
+      "title": "vaadin-tabs Theme Variants",
       "description": "",
       "image": ""
-     }
+    }
   }
   ]
 }

--- a/demo/tabs-basic-demos.html
+++ b/demo/tabs-basic-demos.html
@@ -51,7 +51,7 @@
       </template>
     </vaadin-demo-snippet>
 
-    <h3>Scrolling vertical tabs</h3>
+    <h3>Scrollable vertical tabs</h3>
     <vaadin-demo-snippet id='tabs-basic-demos-scrollable-vertical-tabs'>
       <template preserve-content>
         <vaadin-tabs orientation="vertical" style="height: 130px;">
@@ -74,8 +74,8 @@
       </template>
     </vaadin-demo-snippet>
 
-    <h3>Disabled tabs</h3>
-    <vaadin-demo-snippet id='tabs-basic-demos-disabled-tabs'>
+    <h3>Disabled tab</h3>
+    <vaadin-demo-snippet id='tabs-basic-demos-disabled-tab'>
       <template preserve-content>
         <vaadin-tabs>
           <vaadin-tab>Tab one</vaadin-tab>

--- a/demo/tabs-integration-demos.html
+++ b/demo/tabs-integration-demos.html
@@ -1,4 +1,4 @@
-<dom-module id="tabs-advanced-demos">
+<dom-module id="tabs-integration-demos">
   <template>
     <style include="vaadin-component-demo-shared-styles">
       :host {
@@ -6,8 +6,8 @@
       }
     </style>
 
-    <h3>Integration with iron-pages</h3>
-    <vaadin-demo-snippet id='tabs-advanced-demos-integration-iron-pages'>
+    <h3>Content switcher with iron-pages</h3>
+    <vaadin-demo-snippet id='tabs-integration-demos-integration-iron-pages'>
       <template preserve-content>
         <style>
           page {
@@ -33,8 +33,8 @@
     </vaadin-demo-snippet>
 
 
-    <h3>Wrapping 3rd Party Custom Items</h3>
-    <vaadin-demo-snippet id='tabs-advanced-demos-wrapping-custom-items'>
+    <h3>3rd Party Custom Items</h3>
+    <vaadin-demo-snippet id='tabs-integration-demos-wrapping-custom-items'>
       <template preserve-content>
         <style>
           page {
@@ -46,31 +46,31 @@
         <vaadin-tabs>
           <vaadin-tab>
             <my-custom-item>
-              <img src="https://api.adorable.io/avatars/100/peter.png" width="100" height="100" alt="" slot="icon"></img>
-              Peter
-              <span slot="badge">cool guy</span>
+              <img src="https://api.adorable.io/avatars/100/Katie.png" width="100" height="100" alt="" slot="icon"></img>
+              Katie
+              <span slot="badge">cool</span>
             </my-custom-item>
           </vaadin-tab>
           <vaadin-tab>
             <my-custom-item>
               <img src="https://api.adorable.io/avatars/100/John.png" width="100" height="100" alt="" slot="icon"></img>
               John
-              <span slot="badge">smartass</span>
+              <span slot="badge">friendly</span>
             </my-custom-item>
           </vaadin-tab>
           <vaadin-tab aria-label="Settings">
-            <iron-icon icon="vaadin:cog"></iron-icon>
+            <iron-icon icon="lumo:cog"></iron-icon>
           </vaadin-tab>
         </vaadin-tabs>
       </template>
     </vaadin-demo-snippet>
   </template>
   <script>
-    class TabsAdvancedDemos extends DemoReadyEventEmitter(TabsDemo(Polymer.Element)) {
+    class TabsIntegrationDemos extends DemoReadyEventEmitter(TabsDemo(Polymer.Element)) {
       static get is() {
-        return 'tabs-advanced-demos';
+        return 'tabs-integration-demos';
       }
     }
-    customElements.define(TabsAdvancedDemos.is, TabsAdvancedDemos);
+    customElements.define(TabsIntegrationDemos.is, TabsIntegrationDemos);
   </script>
 </dom-module>


### PR DESCRIPTION
Connects to "Guidelines for component examples"
- Renamed "Basic Examples" to "Basics"
- Renamed "Advanced Usage" to "Integration"
- Renamed "Lumo Theme Variations" to "Theme Variants"
- Minor text changes to examples