### PR TITLE
Use a text color property for inactive tabs

### DIFF
--- a/theme/lumo/vaadin-tab-styles.html
+++ b/theme/lumo/vaadin-tab-styles.html
@@ -15,7 +15,7 @@
         font-weight: 500;
         text-align: center;
         opacity: 1;
-        color: var(--lumo-contrast-60pct);
+        color: var(--lumo-tertiary-text-color);
         transition: 0.15s color, 0.2s transform;
         flex-shrink: 0;
         display: flex;


### PR DESCRIPTION
Use a proper text color property instead of a lower-level contrast color. This makes sure that the text should stay legible even if a theme decides to use a less pronounces contrast color (while still defining properly contrasting text colors).

The options:
- The currently used color is 60% contrast. It has enough contrast to satisfy WCAG requirements for medium bold text (3:1)
- The secondary text color has 70% contrast.
- The tertiary text color has 50% contrast. It doesn’t have enough contrast to satisfy the requirements.

Visually, I would not like to use the secondary text color. I’m proposing that tertiary text color would be enough, as you can get a properly contrasting color by hovering over the tab or by focusing it with the keyboard. But that argument doesn’t apply on touch devices, so I’m quite hesitant to move forward with this. I’m hoping to spark some discussion perhaps with this proposal, if there is some option that would satisfy the visuals as well as a11y requirements.

As a side note, currently, we are using the 60% contrast color for icons, and I’ve been thinking about introducing a property for controlling that specifically. But I’m now wondering would there be a more general purpose color missing, that would apply to both icons and these inactive tabs? Or should we instead consider changing the tertiary text color to use 60% contrast (instead of 50%)?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-tabs/116)
<!-- Reviewable:end -->
