### PR TITLE
Allow icon on top when content is placed inside an anchor

### DIFF
--- a/theme/lumo/vaadin-tab-styles.html
+++ b/theme/lumo/vaadin-tab-styles.html
@@ -130,7 +130,8 @@
         margin-right: 0;
       }
 
-      :host([theme~="icon-on-top"]) {
+      :host([theme~="icon-on-top"]),
+      :host([theme~="icon-on-top"]) ::slotted(a) {
         display: flex;
         flex-direction: column;
         align-items: center;
@@ -138,6 +139,10 @@
         text-align: center;
         padding-bottom: 0.5rem;
         padding-top: 0.25rem;
+      }
+
+      :host([theme~="icon-on-top"]) ::slotted(a) {
+        padding: 0;
       }
 
       :host([theme~="icon-on-top"]) ::slotted(iron-icon) {


### PR DESCRIPTION
Allows the "icon-on-top" theme to work when surrounding the content with an anchor, like this
```html
          <vaadin-tab theme="icon-on-top">
            <a router-link>
              <iron-icon icon="lumo:user"></iron-icon>
              <span>Tab one</span>
            </a>
          </vaadin-tab>
```

Related to vaadin/vaadin-app-layout#48

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-tabs/120)
<!-- Reviewable:end -->
