### PR TITLE
fix: increase slotted link specificity for colors

### DIFF
--- a/theme/lumo/vaadin-tab-styles.html
+++ b/theme/lumo/vaadin-tab-styles.html
@@ -110,7 +110,7 @@
         opacity: 0;
       }
 
-      :host ::slotted(a) {
+      :host ::slotted(a[href]) {
         display: flex;
         width: 100%;
         justify-content: center;
@@ -121,6 +121,11 @@
         text-decoration: none;
         color: inherit;
         outline: none;
+      }
+
+      :host ::slotted(a[href]:hover),
+      :host ::slotted(a[href]:focus) {
+        color: inherit;
       }
 
       :host ::slotted(iron-icon) {


### PR DESCRIPTION
This is especially needed to make demo for links working correctly in Shady DOM:

![screen shot 2019-03-07 at 15 56 03](https://user-images.githubusercontent.com/10589913/53961562-8db11700-40f1-11e9-8d2b-b4d834b5cae0.png)

I would like to avoid using `!important` here. With the suggested fix, demos look as expected, but the styles are still possible to override by the user who presumably knows what he or she is doing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-tabs/127)
<!-- Reviewable:end -->
