### PR TITLE
feat: prepare for TS defs generation [skip ci]

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -28,12 +28,12 @@
   "dependencies": {
     "polymer": "^2.0.0",
     "iron-resizable-behavior": "^2.0.0",
-    "vaadin-themable-mixin": "vaadin/vaadin-themable-mixin#^1.5.2",
-    "vaadin-list-mixin": "vaadin/vaadin-list-mixin#^2.4.0",
-    "vaadin-item": "vaadin/vaadin-item#^2.2.0",
+    "vaadin-themable-mixin": "vaadin/vaadin-themable-mixin#^1.6.1",
+    "vaadin-list-mixin": "vaadin/vaadin-list-mixin#^2.5.0",
+    "vaadin-item": "vaadin/vaadin-item#^2.3.0-alpha1",
     "vaadin-lumo-styles": "vaadin/vaadin-lumo-styles#^1.1.0",
     "vaadin-material-styles": "vaadin/vaadin-material-styles#^1.1.0",
-    "vaadin-element-mixin": "vaadin/vaadin-element-mixin#^2.3.2"
+    "vaadin-element-mixin": "vaadin/vaadin-element-mixin#^2.4.1"
   },
   "devDependencies": {
     "iron-component-page": "^3.0.0",

--- a/gen-tsd.json
+++ b/gen-tsd.json
@@ -1,0 +1,14 @@
+{
+  "excludeFiles": [
+    "wct.conf.js",
+    "index.html",
+    "demo/**/*",
+    "test/**/*",
+    "theme/**/*"
+  ],
+  "autoImport": {
+    "@vaadin/vaadin-list-mixin/interfaces": [
+      "ListOrientation"
+    ]
+  }
+}

--- a/magi-p3-post.js
+++ b/magi-p3-post.js
@@ -1,0 +1,12 @@
+module.exports = {
+  files: [
+    'vaadin-tab.js',
+    'vaadin-tabs.js'
+  ],
+  from: [
+    /import '\.\/theme\/lumo\/vaadin-(.+)\.js';/
+  ],
+  to: [
+    `import './theme/lumo/vaadin-$1.js';\nexport * from './src/vaadin-$1.js';`
+  ]
+};

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   },
   "homepage": "https://vaadin.com/components",
   "files": [
+    "vaadin-*.d.ts",
     "vaadin-*.js",
     "src",
     "theme"

--- a/src/vaadin-tab.html
+++ b/src/vaadin-tab.html
@@ -56,6 +56,10 @@ This program is available under Apache License Version 2.0, available at https:/
           this.setAttribute('role', 'tab');
         }
 
+        /**
+         * @param {!KeyboardEvent} event
+         * @protected
+         */
         _onKeyup(event) {
           const willClick = this.hasAttribute('active');
 

--- a/src/vaadin-tabs.html
+++ b/src/vaadin-tabs.html
@@ -159,6 +159,7 @@ This program is available under Apache License Version 2.0, available at https:/
           return {
             /**
              * Set tabs disposition. Possible values are `horizontal|vertical`
+             * @type {!ListOrientation}
              */
             orientation: {
               value: 'horizontal',
@@ -167,6 +168,7 @@ This program is available under Apache License Version 2.0, available at https:/
 
             /**
              * The index of the selected tab.
+             * @type {number}
              */
             selected: {
               value: 0,
@@ -191,26 +193,38 @@ This program is available under Apache License Version 2.0, available at https:/
           });
         }
 
+        /** @private */
         _scrollForward() {
           this._scroll(-this.__direction * this._scrollOffset);
         }
 
+        /** @private */
         _scrollBack() {
           this._scroll(this.__direction * this._scrollOffset);
         }
 
+        /**
+         * @return {number}
+         * @protected
+         */
         get _scrollOffset() {
           return this._vertical ? this._scrollerElement.offsetHeight : this._scrollerElement.offsetWidth;
         }
 
+        /**
+         * @return {!HTMLElement}
+         * @protected
+         */
         get _scrollerElement() {
           return this.$.scroll;
         }
 
+        /** @private */
         get __direction() {
           return !this._vertical && this.getAttribute('dir') === 'rtl' ? 1 : -1;
         }
 
+        /** @private */
         _updateOverflow() {
           const scrollPosition = this._vertical ? this._scrollerElement.scrollTop : this.__getNormalizedScrollLeft(this._scrollerElement);
           let scrollSize = this._vertical ? this._scrollerElement.scrollHeight : this._scrollerElement.scrollWidth;
@@ -231,6 +245,7 @@ This program is available under Apache License Version 2.0, available at https:/
           this._repaintShadowNodesHack();
         }
 
+        /** @private */
         _repaintShadowNodesHack() {
           // Safari 10 has an issue with repainting shadow root element styles when a host attribute changes.
           // Need this workaround (toggle any inline css property on and off) until the issue gets fixed.


### PR DESCRIPTION
Fixes #157 

Generated TS definition files look like this:

### `vaadin-tab.d.ts`

```ts
import {PolymerElement} from '@polymer/polymer/polymer-element.js';

import {ThemableMixin} from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';

import {ItemMixin} from '@vaadin/vaadin-item/src/vaadin-item-mixin.js';

import {ElementMixin} from '@vaadin/vaadin-element-mixin/vaadin-element-mixin.js';

import {html} from '@polymer/polymer/lib/utils/html-tag.js';

declare class TabElement extends
  ElementMixin(
  ThemableMixin(
  ItemMixin(
  PolymerElement))) {
  ready(): void;
  _onKeyup(event: KeyboardEvent): void;
}

declare global {
  interface HTMLElementTagNameMap {
    "vaadin-tab": TabElement;
  }
}

export {TabElement};
```

### `vaadin-tabs.d.ts`

```ts
import {PolymerElement} from '@polymer/polymer/polymer-element.js';

import {ThemableMixin} from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';

import {ListMixin} from '@vaadin/vaadin-list-mixin/vaadin-list-mixin.js';

import {IronResizableBehavior} from '@polymer/iron-resizable-behavior/iron-resizable-behavior.js';

import {ElementMixin} from '@vaadin/vaadin-element-mixin/vaadin-element-mixin.js';

import {html} from '@polymer/polymer/lib/utils/html-tag.js';

import {afterNextRender} from '@polymer/polymer/lib/utils/render-status.js';

import {mixinBehaviors} from '@polymer/polymer/lib/legacy/class.js';

declare class TabsElement extends
  ElementMixin(
  ListMixin(
  ThemableMixin(
  PolymerElement))) {
  readonly _scrollerElement: HTMLElement;
  selected: number;
  orientation: ListOrientation;
  readonly _scrollOffset: number;
  ready(): void;
}

declare global {
  interface HTMLElementTagNameMap {
    "vaadin-tabs": TabsElement;
  }
}

export {TabsElement};

import {ListOrientation} from '@vaadin/vaadin-list-mixin/interfaces';
```