### PR TITLE
fix: allow null and undefined [skip ci]

### DIFF
--- a/src/vaadin-tabs.html
+++ b/src/vaadin-tabs.html
@@ -168,7 +168,6 @@ This program is available under Apache License Version 2.0, available at https:/
 
             /**
              * The index of the selected tab.
-             * @type {number}
              */
             selected: {
               value: 0,


### PR DESCRIPTION
Fixes #162 

Removed `@type` annotation to also make it aligned with [vaadin-list-mixin](https://github.com/vaadin/vaadin-list-mixin/blob/fe279b420ebdaa0ddf963b39428fd06f5b91511b/vaadin-list-mixin.html#L32-L40)