### PR TITLE
chore: add JSDoc for custom events [skip ci]

### DIFF
--- a/src/vaadin-tabs.d.ts
+++ b/src/vaadin-tabs.d.ts
@@ -54,6 +54,9 @@ export interface TabsEventMap extends HTMLElementEventMap, TabsElementEventMap {
  * `overflow` | It's set to `start`, `end`, none or both. | :host
  *
  * See [ThemableMixin – how to apply styles for shadow parts](https://github.com/vaadin/vaadin-themable-mixin/wiki)
+ *
+ * @fires {CustomEvent} items-changed - Fired when the `items` property changes.
+ * @fires {CustomEvent} selected-changed - Fired when the `selected` property changes.
  */
 declare class TabsElement extends ElementMixin(ListMixin(ThemableMixin(HTMLElement))) {
   readonly _scrollerElement: HTMLElement;

--- a/src/vaadin-tabs.js
+++ b/src/vaadin-tabs.js
@@ -43,6 +43,9 @@ import './vaadin-tab.js';
  *
  * See [ThemableMixin – how to apply styles for shadow parts](https://github.com/vaadin/vaadin-themable-mixin/wiki)
  *
+ * @fires {CustomEvent} items-changed - Fired when the `items` property changes.
+ * @fires {CustomEvent} selected-changed - Fired when the `selected` property changes.
+ *
  * @extends HTMLElement
  * @mixes ElementMixin
  * @mixes ListMixin


### PR DESCRIPTION
This adds autocomplete for VSCode plugin when typing `<vaadin-tabs @`. 

Please note that event type of `e` can not be inferred. That's why I use `@fires {CustomEvent}` without a type. 
The users writing the event listener would still have to import and use corresponding type explicitly.