### PR TITLE
refactor: cleanup IE11 vendor prefixes

### DIFF
--- a/src/vaadin-tabs.js
+++ b/src/vaadin-tabs.js
@@ -76,7 +76,6 @@ class TabsElement extends ElementMixin(
           align-self: stretch;
           overflow-x: auto;
           -webkit-overflow-scrolling: touch;
-          -ms-overflow-style: none;
         }
 
         /* This seems more future-proof than \`overflow: -moz-scrollbars-none\` which is marked obsolete

--- a/theme/lumo/vaadin-tab-styles.js
+++ b/theme/lumo/vaadin-tab-styles.js
@@ -30,7 +30,6 @@ registerStyles(
       min-width: var(--lumo-size-m);
       -webkit-user-select: none;
       -moz-user-select: none;
-      -ms-user-select: none;
       user-select: none;
     }
 


### PR DESCRIPTION
We no longer support IE11 and legacy Edge so let's remove `-ms` vendor prefixes.